### PR TITLE
Fix marionette link

### DIFF
--- a/_pages/implement/marionette-server.md
+++ b/_pages/implement/marionette-server.md
@@ -17,7 +17,7 @@ sidebar:
 
 {% include toc title="" icon="file-text" %}
 
-At the end of August 2018, the [Marionette repository](https://www.github.com) received a substantial update, including detailed documentation that can help developers get started with Marionette, and implement it within their own software. The guides are simple to follow, but assume knowledge of the development environment. In this guide, we'll take you through the steps needed to get Marionette working on a server, using a CentOS server on DigitalOcean's cloud infrastructure. For installing the application on a Mac and connecting with Firefox, see our other [guide](/implement/marionette-client).
+At the end of August 2018, the [Marionette repository](https://github.com/redjack/marionette ) received a substantial update, including detailed documentation that can help developers get started with [Marionette](https://kpdyer.com/publications/usenix2015-marionette.pdf), and implement it within their own software. The guides are simple to follow, but assume knowledge of the development environment. In this guide, we'll take you through the steps needed to get Marionette working on a server, using a CentOS server on DigitalOcean's cloud infrastructure. For installing the application on a Mac and connecting with Firefox, see our other [guide](/implement/marionette-client).
 
 We've chosen CentOS here because it's what the Marionette developers have tested the compiling of Marionette with.
 


### PR DESCRIPTION
I presume you wanted to link to https://github.com/marionette-tg/marionette but that wasn't updated. @redjack however has done some work: https://github.com/redjack/marionette

I would like to get some more info on Marionette elsewhere too.